### PR TITLE
cd to batch file path

### DIFF
--- a/zeronet.cmd
+++ b/zeronet.cmd
@@ -1,4 +1,5 @@
 @echo off
+cd /d "%~dp0"
 if "%1" == "" (
 	Python\python.exe -m zerobundle.run https://github.com/HelloZeroNet/ZeroNet;https://gitlab.com/HelloZeroNet/ZeroNet;https://try.gogs.io/ZeroNet/ZeroNet start.py
 ) else (


### PR DESCRIPTION
When staring from other program but not clicking in explorer.exe,  the relative path maybe is wrong. Such as start zeronet.cmd from AutoHotkey.